### PR TITLE
added user's name to embed

### DIFF
--- a/cogs/big_ben.py
+++ b/cogs/big_ben.py
@@ -285,6 +285,8 @@ class BigBen(utils.Cog):
         # Output to user baybeeee
         fig.savefig('activity.png', bbox_inches='tight', pad_inches=0)
         with utils.Embed() as embed:
+            # Build the embed   
+            embed = discord.Embed(title= f"{ctx.author.name}'s average reaction time")
             embed.set_image(url="attachment://activity.png")
         await ctx.send(embed=embed, file=discord.File("activity.png"))
 


### PR DESCRIPTION
bb.bongdist will show the users embed since ux go brrr

might not be needed, but would be nice
<img width="635" alt="Screen Shot 2020-09-23 at 14 19 30" src="https://user-images.githubusercontent.com/32599075/94065036-cc77f200-fda7-11ea-844f-ee61bc90d6ea.png">
